### PR TITLE
Don’t set cookie to nil!

### DIFF
--- a/lib/moxiworks_platform/session.rb
+++ b/lib/moxiworks_platform/session.rb
@@ -3,7 +3,11 @@ module  MoxiworksPlatform
   class Session
     include Singleton
 
-    attr_accessor :cookie
+    attr_reader :cookie
+
+    def cookie=(value)
+      @cookie = value unless value.nil?
+    end
 
   end
 end


### PR DESCRIPTION
The API provides a response header, `set_cookie`, that should be forwarded in request header, `cookie` for each subsequent request.

A new `set_cookie` value is provided when the rate limit period resets.

Currently, the code attempts to set a new value to be used in the `cookie` request header on each response even if the `set_cookie` response header is absent.

This results in subsequent requests being sent with a `nil` value for the `cookie` header.

This happens [here](https://github.com/moxiworks-platform/moxiworks-ruby/blob/19d19ee531d19db0f081c598c7ce5e49cc9f056f/lib/moxiworks_platform/resource.rb#L72) when the `rescue nil` fires.

The solution simply avoids setting `cookie` on the singleton `Session` class to a `nil` value.